### PR TITLE
Add Makefile for running all live-server in a single shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: dev
+
+install:
+	@echo "Installing all dependencies..."
+	@go mod tidy
+
+dev:
+	@echo "Starting all services with hot reloading..."
+	@trap 'kill %1; kill %2; kill %3' SIGINT; \
+	templ generate --watch & \
+	tailwindcss -i ./static/css/input.css -o ./static/css/output.css --watch & \
+	air & \
+	wait
+
+# A command to stop all background processes if needed
+stop:
+	@echo "Stopping all background processes..."
+	@pkill -f "templ generate --watch"
+	@pkill -f "tailwindcss -i ./static/css/input.css -o ./static/css/output.css --watch"
+	@pkill -f "air"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ air
 
 To configure air, you can modify .air.toml in the root of the project. (it will be auto-generated after the first time you run air in your repo)
 
+### Running everything with hot-reload
+To run everything with hot reloading, a makefile command starts the above mentioned processes in the background, so `templ`, `tailwindcss` and `go` live-servers can run in a single shell.
+```bash
+make dev
+```
+
 ## Project Overview
 
 This project has a few core concepts to help you get going, let's start with ./main.go


### PR DESCRIPTION
Adding a [Makefile](https://opensource.com/article/18/8/what-how-makefile) that runs all watchers in background processes, so the whole development flow can run in a single shell.
This way theres no need to run the processes in 3 different terminal windows.

As demonstrated here, the processes react to changes in `.go`, `.templ`, and `.css` files, and rebuild the necessary files.
```
❯ make dev
Starting all services with hot reloading...
(✓) Watching files

  __    _   ___
 / /\  | | | |_)
/_/--\ |_| |_| \_ v1.52.3, built with Go go1.22.5

watching .
watching internal
watching internal/component
watching internal/middleware
watching internal/template
watching internal/view
watching static
watching static/css
watching static/svg
!exclude tmp
building...

Rebuilding...

Done in 93ms.
running...
server is running on port
main.go has changed
building...
running...
server is running on port

Rebuilding...

Done in 85ms.

Rebuilding...

Done in 27ms.

Rebuilding...

Done in 19ms.
internal/template/template_templ.go has changed
building...
running...
server is running on port
```